### PR TITLE
React native compatibility fix

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,9 @@
 // https://github.com/flitbit/diff#differences
 import differ from 'deep-diff';
 
+const consoleGroup = (console.group || console.log).bind(console);
+const consoleGroupEnd = (console.groupEnd || function(){}).bind(console);
+
 const dictionary = {
   E: {
     color: '#2196F3',
@@ -50,7 +53,7 @@ function logger({ getState }) {
 
     const diff = differ(prevState, newState);
 
-    console.group('diff @', `${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}`);
+    consoleGroup('diff @', `${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}`);
     if (diff) {
       diff.forEach((elem) => {
         const { kind } = elem;
@@ -61,7 +64,7 @@ function logger({ getState }) {
     } else {
       console.log('—— no diff ——');
     }
-    console.groupEnd('diff');
+    consoleGroupEnd('diff');
 
     return returnValue;
   };


### PR DESCRIPTION
React native doesn't support console.group

![](https://cloud.githubusercontent.com/assets/817046/11570154/09ec0a2e-99f6-11e5-9db8-f3e885e34a24.png)

so I swap the console.group calls to console.log for a more compatible, albeit not as fancy, output.
