### PR TITLE
Minimal possible array fix

### DIFF
--- a/build/logger.js
+++ b/build/logger.js
@@ -50,7 +50,7 @@ function render(diff) {
     case 'D':
       return '' + path.join('.');
     case 'A':
-      return (path.join('.') + '[' + index + ']', item);
+      return [path.join('.') + '[' + index + ']', item];
     default:
       return null;
   }

--- a/src/logger.js
+++ b/src/logger.js
@@ -35,7 +35,7 @@ function render(diff) {
   case 'D':
     return `${path.join('.')}`;
   case 'A':
-    return (`${path.join('.')}[${index}]`, item);
+    return [`${path.join('.')}[${index}]`, item];
   default:
     return null;
   }


### PR DESCRIPTION
I know about #1, but until a perfect fix, may we have the dumbest simplest fix for what seems an invalid use of a comma operator?

Before:
![before](https://cloud.githubusercontent.com/assets/113721/12265897/9202e146-b948-11e5-8237-cd5ec17709e6.png)

After:
![after](https://cloud.githubusercontent.com/assets/113721/12265896/91e4819c-b948-11e5-92d2-7fa80c070c84.png)
